### PR TITLE
Support for non-source packages

### DIFF
--- a/flask_pypi_proxy/app.py
+++ b/flask_pypi_proxy/app.py
@@ -91,11 +91,9 @@ def configure_logging(app):
     :param app: the application that will be used to register the URLs.
     '''
     if not app.debug:
-        file_logger = logging.FileHandler(app.config['LOGGING_PATH'])
-        logging_level = getattr(logging, app.config['LOGGING_LEVEL'])
-        file_logger.setLevel(logging_level)
-        app.logger.setLevel(logging_level)
-        app.logger.addHandler(file_logger)
+        logging.basicConfig(filename=app.config['LOGGING_PATH'],
+                            level=getattr(logging, app.config['LOGGING_LEVEL']),
+                            format='%(asctime)s [%(levelname)s] %(message)s')
 
 read_configuration(app)
 configure_logging(app)

--- a/flask_pypi_proxy/views/package.py
+++ b/flask_pypi_proxy/views/package.py
@@ -17,27 +17,30 @@ from os.path import join, exists
 from requests import get, head
 # from subprocess import Popen
 
-
-@app.route('/packages/source/<source_letter>/<package_name>/<package_file>',
+# robin-jarry: changed the "source" to a variable placeholder in the URL to 
+# deal with non-source packages (usually stored in /packages/<python version>/...)
+@app.route('/packages/<package_type>/<letter>/<package_name>/<package_file>',
            methods=['GET', 'HEAD'])
-def package(source_letter, package_name, package_file):
+def package(package_type, letter, package_name, package_file):
     ''' Downloads the egg
 
-    :param str source_letter: the first char of the package name. For example:
+    :param str package_type: the nature of the package. For example:
+                              'source' or '2.7'
+    :param str letter: the first char of the package name. For example:
                               D
     :param str package_name: the name of the package. For example: Django
     :param str package_file: the name of the package and it's version. For
-                             example: Django==1.5.0
+                             example: Django-1.5.0.tar.gz
     '''
     egg_filename = join(get_base_path(), package_name, package_file)
+    url = app.config['PYPI_URL'] + 'packages/%s/%s/%s/%s' % (package_type,
+                                                             letter,
+                                                             package_name,
+                                                             package_file)
     if request.method == 'HEAD':
         # in this case the content type of the file is what is
         # required
         if not exists(egg_filename):
-            url = app.config['PYPI_URL'] + 'packages/source/%s/%s/%s' % (
-                                        source_letter,
-                                        package_name,
-                                        package_file)
             pypi_response = head(url)
             return _respond(pypi_response.content, pypi_response.headers['content-type'])
 
@@ -64,10 +67,6 @@ def package(source_letter, package_name, package_file):
         #       example: py-bcrypt
 
         package_path = get_package_path(package_name)
-        url = app.config['PYPI_URL'] + 'packages/source/%s/%s/%s' % (
-                                        source_letter,
-                                        package_name,
-                                        package_file)
         app.logger.debug('Starting to download: %s using the url: %s',
                          package_file, url)
         pypi_response = get(url)

--- a/flask_pypi_proxy/views/simple.py
+++ b/flask_pypi_proxy/views/simple.py
@@ -105,21 +105,20 @@ def simple_package(package_name):
         for anchor in p("a"):
             panchor = PyQuery(anchor)
             href = panchor.attr("href")
-            if not href.startswith('../../packages/source'):
+            # robin-jarry: modified the href to ../../packages/
+            # so that it works also for non-source packages (.egg, .exe and .msi)
+            if not href.startswith('../../packages/'):
                 # then the link is to an external server.
                 # I will change it so it references the local server
                 # and this proxy has the values from that server.
-
                 # For example:
                 #   view-source:http://pypi.python.org/simple/nose/
                 # the lastest versions references somethingaboutrange.com
                 # and because of that PIP won't use this proxy
-                package_version = split(href)[-1]
-                corrected_href = '../../packages/source/%s/%s/%s' % (
-                        package_name[0],
-                        package_name,
-                        package_version
-                )
-                panchor.attr("href", corrected_href)
+                
+                # robin-jarry: if the URL does not start with ../../packages/ 
+                # it should be removed for now. Until we find a way to deal 
+                # with proxying other servers than pypi.python.org.
+                panchor.remove()
         content = p.outerHtml()
         return content

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
-from setuptools import setup, find_packages
+#!/bin/env python
 
+from setuptools import setup, find_packages
 
 setup(
     name='Flask-Pypi-Proxy',
-    version='0.0.3',
+    version='0.0.4.dev',
     description='A Pypi proxy',
     long_description=open('README.rst').read(-1),
     author='Tomas Zulberti',


### PR DESCRIPTION
Hello,

I just started using your app and I must, say : "Finally someone has done that!!!"

One problem though, for now, when you try to install packages that do not have source distributions (such as [Sphinx](https://pypi.python.org/simple/Sphinx/)) it fails because it changes the URL of the packages from this:

```
../../packages/2.7/S/Sphinx/Sphinx-1.1.2-py2.7.egg
```

to this

```
../../packages/source/S/Sphinx/Sphinx-1.1.2-py2.7.egg
```

And therefore gets a 404 not found from pypi.python.org afterwards.

Pull request, coming soon™ Keep up the good work.

--Robin
