### PR TITLE
External download links handling

### DIFF
--- a/flask_pypi_proxy/utils.py
+++ b/flask_pypi_proxy/utils.py
@@ -39,3 +39,11 @@ def get_md5_for_content(package_content):
     '''
     res = md5(package_content)
     return res.hexdigest()
+
+
+def url_is_egg_file(url):
+    return url is not None and (   url.lower().endswith('.zip')
+                                or url.lower().endswith('.tar.gz')
+                                or url.lower().endswith('.egg')
+                                or url.lower().endswith('.exe')
+                                or url.lower().endswith('.msi'))

--- a/flask_pypi_proxy/views/package.py
+++ b/flask_pypi_proxy/views/package.py
@@ -33,10 +33,17 @@ def package(package_type, letter, package_name, package_file):
                              example: Django-1.5.0.tar.gz
     '''
     egg_filename = join(get_base_path(), package_name, package_file)
-    url = app.config['PYPI_URL'] + 'packages/%s/%s/%s/%s' % (package_type,
-                                                             letter,
-                                                             package_name,
-                                                             package_file)
+    
+    remote = request.args.get('remote')
+    
+    if remote:
+        # the requested link is not on pypi.python.org, we need to use the remote URL
+        url = remote
+    else:
+        url = app.config['PYPI_URL'] + 'packages/%s/%s/%s/%s' % (package_type,
+                                                                 letter,
+                                                                 package_name,
+                                                                 package_file)
     if request.method == 'HEAD':
         # in this case the content type of the file is what is
         # required
@@ -62,9 +69,6 @@ def package(package_type, letter, package_name, package_file):
     else:
         # Downloads the egg from pypi and saves it locally, then
         # it will return it.
-
-        # TODO: there are some problem here with some packages. For
-        #       example: py-bcrypt
 
         package_path = get_package_path(package_name)
         app.logger.debug('Starting to download: %s using the url: %s',

--- a/flask_pypi_proxy/views/simple.py
+++ b/flask_pypi_proxy/views/simple.py
@@ -4,16 +4,18 @@
 ''' Gets the list of the packages that can be downloaded.
 '''
 
+import urllib
+import urlparse
 from collections import namedtuple
 from os import listdir
-from os.path import join, exists, split
+from os.path import join, exists, basename
 
 from flask import abort, render_template
 from pyquery import PyQuery
 from requests import get
 
 from flask_pypi_proxy.app import app
-from flask_pypi_proxy.utils import get_package_path, get_base_path, is_private
+from flask_pypi_proxy.utils import get_package_path, get_base_path, is_private, url_is_egg_file
 
 
 VersionData = namedtuple('VersionData', ['name', 'md5'])
@@ -102,23 +104,95 @@ def simple_package(package_name):
 
         content = response.content
         p = PyQuery(content)
+        external_links = set()
         for anchor in p("a"):
             panchor = PyQuery(anchor)
-            href = panchor.attr("href")
+            href = panchor.attr('href')
             # robin-jarry: modified the href to ../../packages/
             # so that it works also for non-source packages (.egg, .exe and .msi)
-            if not href.startswith('../../packages/'):
-                # then the link is to an external server.
-                # I will change it so it references the local server
-                # and this proxy has the values from that server.
-                # For example:
-                #   view-source:http://pypi.python.org/simple/nose/
-                # the lastest versions references somethingaboutrange.com
-                # and because of that PIP won't use this proxy
-                
-                # robin-jarry: if the URL does not start with ../../packages/ 
-                # it should be removed for now. Until we find a way to deal 
-                # with proxying other servers than pypi.python.org.
-                panchor.remove()
+            parsed = urlparse.urlparse(href)
+            
+            if parsed.hostname:
+                # the link is to an external server.
+                if parsed.hostname == 'pypi.python.org':
+                    # we remove the hostname to make the URL relative
+                    panchor.attr('href', parsed.path)
+                else:
+                    if panchor.attr('rel') == 'download':
+                        if url_is_egg_file(parsed.path):
+                            # href points to a filename
+                            external_links.add('<a href="%s">%s</a>' % (href, basename(parsed.path)))
+                        else:
+                            # href points to an external page where we will find 
+                            # links to package files
+                            external_links.update(find_external_links(app, href))
+                    # what ever happens, we remove the link for now
+                    # we'll add the external_links after that we found after
+                    panchor.remove()                    
+            else:
+                # local link to pypi.python.org
+                if not href.startswith('../../packages/'):
+                    # ignore anything else than package links
+                    panchor.remove()
+            
+        # after collecting all external links, we insert them in the html page
+        for link in external_links:
+            plink = PyQuery(link)
+            href = plink.attr('href')
+            plink.attr('href', convert_to_internal_url(href, package_name, basename(href)))
+            p('a').after(plink)
+        
         content = p.outerHtml()
         return content
+
+
+def find_external_links(app, url):
+    '''Look for links to files in a web page and returns a set.
+    '''
+    links = set()
+    response = get(url)
+    if response.status_code != 200:
+        app.logger.warning('Error while getting proxy info for: %s'
+                           'Errors details: %s', url,
+                           response.text)
+    else:
+        if response.content:
+            p = PyQuery(response.content)
+            for anchor in p("a"):
+                panchor = PyQuery(anchor)
+                href = panchor.attr("href")
+                if url_is_egg_file(href):
+                    # href points to a filename
+                    href = get_absolute_url(href, url)
+                    links.add('<a href="%s">%s</a>' % (href, panchor.text()))
+    return links
+
+
+def get_absolute_url(url, root_url):
+    '''Make relative URLs absolute
+    
+    >>> get_absolute_url('/src/blah.zip', 'https://awesome.org/')
+    'https://awesome.org/src/blah.zip'
+    >>> get_absolute_url('http://foo.bar.org/blah.zip', 'https://awesome.org/')
+    'http://foo.bar.org/blah.zip'
+    '''
+    parsed = urlparse.urlparse(url)
+    if parsed.scheme:
+        return url
+    else:
+        return urlparse.urljoin(root_url, parsed.path)
+    
+
+def convert_to_internal_url(external_url, package_name, filename):
+    '''Convert an external URL (i.e. not on pypi.python.org) to something 
+    that can be sent to the clients behind our proxy.
+    
+    Example:
+    
+    >>> convert_to_internal_url('http://foo.bar.org/src/blah-1.2.zip', 'blah', 'blah-1.2.zip')
+    '../../packages/external/b/blah/blah-1.2.zip?remote=http%3A%2F%2Ffoo.bar.org%2Fsrc%2Fblah-1.2.zip'
+    '''
+    return '../../packages/external/%s/%s/%s?%s' % (package_name[0],
+                                                    package_name,
+                                                    filename,
+                                                    urllib.urlencode({'remote': external_url}))

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='Flask-Pypi-Proxy',
-    version='0.0.4.dev',
+    version='0.0.5',
     description='A Pypi proxy',
     long_description=open('README.rst').read(-1),
     author='Tomas Zulberti',


### PR DESCRIPTION
Hello again,

I added a new feature: now if a page (such as https://pypi.python.org/simple/nose/ or https://pypi.python.org/simple/py-bcrypt/ or https://pypi.python.org/simple/PIL/) does not have direct links to package files, the proxy will make some voodoo to make it downloadable anyway (via a special attribute `?remote=<remote_url>`). See the code for details :-)

The system should now work with all packages :+1: 

Signed-off-by: robin-jarry robin@jarry.cc
