### PR TITLE
Use SSL for pypi

### DIFF
--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -28,7 +28,7 @@ PRIVATE_EGGS
 
 PYPI_URL
     the URL where from where the eggs should be downloaded. By default it
-    uses: http://pypi.python.org but it can be changed to any other. This might
+    uses: https://pypi.python.org but it can be changed to any other. This might
     be useful, for example if you have a development/local proxy, that
     uses the production proxy.
 

--- a/flask_pypi_proxy/app.py
+++ b/flask_pypi_proxy/app.py
@@ -8,7 +8,7 @@ import json
 import logging
 from flask import Flask
 
-def read_configuration(app, pypi_url='http://pypi.python.org',
+def read_configuration(app, pypi_url='https://pypi.python.org',
                        private_eggs=[]):
     ''' Reads the configuration by using the system file or the configuration
     file.


### PR DESCRIPTION
pypi.python.org does not serve plain-text http anymore